### PR TITLE
use the $make variable in make_bin_check

### DIFF
--- a/run_build.pl
+++ b/run_build.pl
@@ -1427,7 +1427,7 @@ sub make_bin_check
 
     print time_str(),"running make bin check ...\n" if $verbose;
 
-    my @makeout = `cd $pgsql/src/bin && make NO_LOCALE=1 check 2>&1`;
+    my @makeout = `cd $pgsql/src/bin && $make NO_LOCALE=1 check 2>&1`;
 
     my $status = $? >>8;
 


### PR DESCRIPTION
raw make is used and breaks the test when the default make is not gmake