### PR TITLE
When an earlier run crashed during copy_source(), repair the repository.

### DIFF
--- a/PGBuild/SCM.pm
+++ b/PGBuild/SCM.pm
@@ -683,6 +683,9 @@ sub checkout
 
 	if (-d $target)
 	{
+		# If a run crashed during copy_source(), repair.
+		move "./git-save", "$target/.git";
+
 		chdir $target;
 		my @branches = `git branch 2>&1`;    # too trivial for run_log
 		unless (grep { /^\* bf_$branch$/ } @branches)


### PR DESCRIPTION
Without this, reviving the animal required operator intervention.