### PR TITLE
Add new location of pg_upgrade logs in new cluster's pg_upgrade_outpu…

### DIFF
--- a/PGBuild/Modules/TestUpgrade.pm
+++ b/PGBuild/Modules/TestUpgrade.pm
@@ -139,6 +139,7 @@ sub check
          $self->{pgsql}/src/bin/pg_upgrade/*.log
          $self->{pgsql}/src/bin/pg_upgrade/log/*
          $self->{pgsql}/src/bin/pg_upgrade/tmp_check/*/*.diffs
+         $self->{pgsql}/src/bin/pg_upgrade/tmp_check/data/pg_upgrade_output.d/log/*
          $self->{pgsql}/src/test/regress/*.diffs"
 	);
 	$log->add_log($_) foreach (@logfiles);


### PR DESCRIPTION
…t.d/

A change is planned in upstream to move all the dump and log files
generated by pg_upgrade to the data folder upgraded, as of a subfolder
called pg_upgrade_output.d/, with log/ including all the per-database
log files.  This location is added into the paths scanned when running
the upgrade tests in the buildfarm.