### PR TITLE
Update TestUpgrade.pm to grab for any existing log files with Postgre…

### DIFF
--- a/PGBuild/Modules/TestUpgrade.pm
+++ b/PGBuild/Modules/TestUpgrade.pm
@@ -18,6 +18,7 @@ use PGBuild::SCM;
 use PGBuild::Utils qw(:DEFAULT $steps_completed);
 
 use File::Basename;
+use File::Find;
 
 use strict;
 use warnings;
@@ -139,9 +140,18 @@ sub check
          $self->{pgsql}/src/bin/pg_upgrade/*.log
          $self->{pgsql}/src/bin/pg_upgrade/log/*
          $self->{pgsql}/src/bin/pg_upgrade/tmp_check/*/*.diffs
-         $self->{pgsql}/src/bin/pg_upgrade/tmp_check/data/pg_upgrade_output.d/log/*
          $self->{pgsql}/src/test/regress/*.diffs"
 	);
+
+	# Extra location of logs, changed as per Postgres 15~ with multiple
+	# levels of subdirectories.
+	find(
+		sub {
+			push @logfiles, $File::Find::name
+				if $File::Find::name =~ m/.*\.log/;
+		},
+		"$self->{pgsql}/src/bin/pg_upgrade/tmp_check/data/pg_upgrade_output.d/");
+
 	$log->add_log($_) foreach (@logfiles);
 
 	my $status = $? >> 8;


### PR DESCRIPTION
…s 15~

Upstream has changed the location of the log files generated by
pg_upgrade to be in a directory located within the target cluster, named
pg_upgrade_output.d.  Its structure has changed to use more
subdirectories, and glob() is not really able to cope with that.  This
modifies the logic grabbing the log files to use "find" and grab all the
files within pg_upgrade_output.d that are prefixed with ".log".