### PR TITLE
Allow all build_env variables for meson_env

### DIFF
--- a/run_build.pl
+++ b/run_build.pl
@@ -1620,12 +1620,14 @@ sub _meson_env
 	# these should be safe to appear on the log and could be required
 	# for running tests
 	my @safe_set = qw(
-	  PATH
-	  PGUSER PGHOST PG_TEST_PORT_DIR PG_TEST_EXTRA
+	  PATH PGUSER PGHOST
 	  PG_TEST_USE_UNIX_SOCKETS PG_REGRESS_SOCK_DIR
-	  SystemRoot TEMP TMP MSYS
-	  TEMP_CONFIG  PGCTLTIMEOUT
+	  SystemRoot TEMP TMP MSYS TEMP_CONFIG
 	  USER USERNAME USERDOMAIN);
+
+	# variables specified in build_env are always required by definition
+	# and should be safe to appear in the logs, too.
+	push(@safe_set, keys %{$PGBuild::conf{build_env}});
 
 	foreach my $setting (@safe_set)
 	{


### PR DESCRIPTION
I hit the same thing as #31 in a different context:

Currently setting up an animal to run in a docker container. Because I don't know the user/group ids that the container is run with in advance, I am using `nss_wrapper` in `LD_PRELOAD` to fake a user and group name for initdb. This is similar to how the library/postgres docker image does it. But when building with meson, those environment variables are not passed on and the check fails.

I assume that the intention of the safe_set filtering for meson_env is to hide potential secrets (e.g. the secret for the animal itself, which could be stored in an environment variable). Anything that is set explicitly in build_env, should be safe to pass on, though. This PR does that.

I also removed some of the variables from the hardcoded list, because I assume they are set via build_env anyway. But I might be mistaken on that.