### PR TITLE
Disable pg_upgrade-check when building with meson and --from-source

### DIFF
--- a/PGBuild/Modules/TestUpgrade.pm
+++ b/PGBuild/Modules/TestUpgrade.pm
@@ -48,7 +48,8 @@ sub setup
 
 	# this obviates the need of any meson support in this module, as
 	# this has been in since release 15
-	return if -d "$buildroot/$branch/pgsql/src/bin/pg_upgrade/t";
+	my $srcdir = $from_source || "$buildroot/$branch/pgsql";
+	return if -d "$srcdir/src/bin/pg_upgrade/t";
 
 	die
 	  "overly long build root $buildroot will cause upgrade problems - try something shorter than 46 chars"


### PR DESCRIPTION
The check in `PGBuild/Modules/TestUpgrade.pm` too see whether pg_upgrade tests are available assumes the build is done without `--from-source`. Doing a meson+from_source build thus fails the pg_upgrade check.

The `my $srcdir` line is borrowed from `TestUpgradeXversion.pm`, which already does better.