### PR TITLE
Have git verify the repository

### DIFF
--- a/PGBuild/SCM.pm
+++ b/PGBuild/SCM.pm
@@ -1060,9 +1060,15 @@ sub _update_target
 	my @gitlog;
 
 	# If a run crashed during copy_source(), repair.
-	if (-d "./git-save" && !-d "$target/.git")
+	if (-d "./git-save")
 	{
-		move "./git-save", "$target/.git";
+		system(qq{git -C $target rev-parse --is-inside-work-tree > $devnull 2>&1});
+		if ($?)
+		{
+			require File::Path;
+			File::Path::remove_tree("$target/.git");
+			move "./git-save", "$target/.git";
+		}
 	}
 
 	chdir $target;


### PR DESCRIPTION
Rather than simply check for the presence of `.git` when `git-save` exists, run `git rev-parse --is-inside-work-tree` and replace the `.git` directory when it returns an error. This will fix corrupted `.git` directories left over from previous builds, as well as missing `.git` directories.

Was inspired to make this change when my build farm animal started failing builds after a couple of runs with this error:

```
baza:REL_17_STABLE [14:38:24] checking out source ...
Missing checked out branch bf_REL_17_STABLE:
fatal: not a git repository (or any of the parent directories): .git
Branch: REL_17_STABLE
Stage pgsql-Git failed with status 1
```

The `.git` directory did in fact exist, but there wasn't much in it:

```
$ ls -la build/REL_17_STABLE/pgsql/.git/
total 16
drwxr-xr-x 4 animal animal 4096 Aug 10 23:18 .
drwxr-xr-x 3 animal animal 4096 Aug 10 23:20 ..
drwxr-xr-x 2 animal animal 4096 Aug 10 23:18 info
drwxr-xr-x 3 animal animal 4096 Aug 10 23:18 objects
```

But `git-save` had much more:

```
ll build/REL_17_STABLE/git-save/
total 752K
-rw-r--r-- 1 animal animal 4.1K Aug 10 23:18 FETCH_HEAD
-rw-r--r-- 1 animal animal   33 Aug 10 20:50 HEAD
-rw-r--r-- 1 animal animal   41 Aug 10 23:18 ORIG_HEAD
lrwxrwxrwx 1 animal animal   41 Aug 10 17:28 config -> /home/animal/build/HEAD/pgsql/.git/config
-rw-r--r-- 1 animal animal   96 Aug 10 23:18 gc.log.lock
-rw-r--r-- 1 animal animal   14 Aug 10 23:18 gc.pid
lrwxrwxrwx 1 animal animal   40 Aug 10 17:28 hooks -> /home/animal/build/HEAD/pgsql/.git/hooks
-rw-r--r-- 1 animal animal 724K Aug 10 23:18 index
lrwxrwxrwx 1 animal animal   39 Aug 10 17:28 info -> /home/animal/build/HEAD/pgsql/.git/info
drwxr-xr-x 2 animal animal 4.0K Aug 10 23:18 logs
lrwxrwxrwx 1 animal animal   42 Aug 10 17:28 objects -> /home/animal/build/HEAD/pgsql/.git/objects
```

I have no idea how or why the directory was corrupted, but this patch fixes the issue by restoring an uncorrupted `.git` directory.