### PR TITLE
Include version number in user agent

### DIFF
--- a/PGBuild/WebTxn.pm
+++ b/PGBuild/WebTxn.pm
@@ -122,7 +122,7 @@ sub run_web_txn
 	my $sig = '.256h.' . hmac_sha256_hex($content, $secret);
 
 	my $ua = LWP::UserAgent->new;
-	$ua->agent("Postgres Build Farm Reporter");
+	$ua->agent("Postgres Build Farm Reporter/$VERSION");
 	if (my $proxy = $ENV{BF_PROXY})
 	{
 		my $targetURI = URI->new($target);

--- a/manage_alerts.pl
+++ b/manage_alerts.pl
@@ -86,7 +86,7 @@ while (my ($envkey, $envval) = each %{ $PGBuild::conf{build_env} })
 }
 
 my $ua = LWP::UserAgent->new;
-$ua->agent("Postgres Build Farm Reporter");
+$ua->agent("Postgres Build Farm Reporter/$VERSION");
 if (my $proxy = $ENV{BF_PROXY})
 {
 	my $targetURI = URI->new($target);

--- a/run_branches.pl
+++ b/run_branches.pl
@@ -307,7 +307,7 @@ sub get_branches_of_interest
 		# make sure we have https protocol support if it's required
 		require LWP::Protocol::https if $url =~ /^https:/;
 		my $ua = LWP::UserAgent->new;
-		$ua->agent("Postgres Build Farm Reporter");
+		$ua->agent("Postgres Build Farm Reporter/$VERSION");
 		if (my $proxy = $ENV{BF_PROXY})
 		{
 			my $targetURI = URI->new($url);

--- a/setnotes.pl
+++ b/setnotes.pl
@@ -89,7 +89,7 @@ while (my ($envkey, $envval) = each %{ $PGBuild::conf{build_env} })
 }
 
 my $ua = LWP::UserAgent->new;
-$ua->agent("Postgres Build Farm Reporter");
+$ua->agent("Postgres Build Farm Reporter/$VERSION");
 if (my $proxy = $ENV{BF_PROXY})
 {
 	my $targetURI = URI->new($target);

--- a/update_personality.pl
+++ b/update_personality.pl
@@ -100,7 +100,7 @@ while (my ($envkey, $envval) = each %{ $PGBuild::conf{build_env} })
 }
 
 my $ua = LWP::UserAgent->new;
-$ua->agent("Postgres Build Farm Reporter");
+$ua->agent("Postgres Build Farm Reporter/$VERSION");
 if (my $proxy = $ENV{BF_PROXY})
 {
 	my $targetURI = URI->new($upgrade_target);


### PR DESCRIPTION
Make the User-Agent http header include the version number of the client. This can help in some server-side debugging scenarios.

(As a bonus this makes the agent standards compliant, but I doubt anybody cares about that standard so that's not the reason).